### PR TITLE
Add support for RETURNING clause

### DIFF
--- a/lib/petrol.mli
+++ b/lib/petrol.mli
@@ -1019,6 +1019,14 @@ module Query : sig
         {!Petrol.Query.order_by}, this function allows passing a list
         of elements to be ordered by) *)
 
+  val returning :
+    'c Expr.expr_list -> ('a, [< `UPDATE | `INSERT | `DELETE] as 'b) t -> ('c, 'b) t
+  (** [returning expr] corresponds to the SQL [RETURNING {expr}].
+
+      The [RETURNING] clause is a non-standard extension supported by
+      PostgreSQL since version 8.2 (2006-12-05), and by SQLite since version
+      3.35.0 (2021-03-12). *)
+
 end
 
 module StaticSchema : sig

--- a/test/static/test-delete-multiple.t
+++ b/test/static/test-delete-multiple.t
@@ -1,9 +1,14 @@
   $ ../test_static_person.exe init test.db
   $ ../test_static_person.exe add test.db john 30
+  - id: 1
   $ ../test_static_person.exe add test.db sally 15
+  - id: 2
   $ ../test_static_person.exe add test.db barry 14
+  - id: 3
   $ ../test_static_person.exe add test.db bob 20
+  - id: 4
   $ ../test_static_person.exe add test.db harry 10
+  - id: 5
   $ ../test_static_person.exe delete test.db sally
   $ ../test_static_person.exe delete test.db barry
   $ ../test_static_person.exe delete test.db bob

--- a/test/static/test-delete.t
+++ b/test/static/test-delete.t
@@ -1,9 +1,14 @@
   $ ../test_static_person.exe init test.db
   $ ../test_static_person.exe add test.db john 30
+  - id: 1
   $ ../test_static_person.exe add test.db sally 15
+  - id: 2
   $ ../test_static_person.exe add test.db barry 14
+  - id: 3
   $ ../test_static_person.exe add test.db bob 20
+  - id: 4
   $ ../test_static_person.exe add test.db harry 10
+  - id: 5
   $ ../test_static_person.exe delete test.db sally
   $ ../test_static_person.exe list test.db
   [0] - name: john; age: 30

--- a/test/static/test-find-missing.t
+++ b/test/static/test-find-missing.t
@@ -1,8 +1,13 @@
   $ ../test_static_person.exe init test.db
   $ ../test_static_person.exe add test.db john 30
+  - id: 1
   $ ../test_static_person.exe add test.db sally 15
+  - id: 2
   $ ../test_static_person.exe add test.db barry 14
+  - id: 3
   $ ../test_static_person.exe add test.db bob 20
+  - id: 4
   $ ../test_static_person.exe add test.db harry 10
+  - id: 5
   $ ../test_static_person.exe find-by test.db darren
   not found

--- a/test/static/test-find-older-than.t
+++ b/test/static/test-find-older-than.t
@@ -1,9 +1,14 @@
   $ ../test_static_person.exe init test.db
   $ ../test_static_person.exe add test.db john 30
+  - id: 1
   $ ../test_static_person.exe add test.db sally 9
+  - id: 2
   $ ../test_static_person.exe add test.db barry 14
+  - id: 3
   $ ../test_static_person.exe add test.db bob 20
+  - id: 4
   $ ../test_static_person.exe add test.db harry 10
+  - id: 5
   $ ../test_static_person.exe find-older-than test.db 10
   [0] - name: john; age: 30
   [1] - name: barry; age: 14

--- a/test/static/test-insert-duplicate.t
+++ b/test/static/test-insert-duplicate.t
@@ -1,9 +1,14 @@
   $ ../test_static_person.exe init test.db
   $ ../test_static_person.exe add test.db john 30
+  - id: 1
   $ ../test_static_person.exe add test.db sally 15
+  - id: 2
   $ ../test_static_person.exe add test.db barry 14
+  - id: 3
   $ ../test_static_person.exe add test.db bob 20
+  - id: 4
   $ ../test_static_person.exe add test.db harry 10
+  - id: 5
   $ ../test_static_person.exe add test.db harry 10
-  Fatal error: exception Response from <sqlite3:///test.db> failed: UNIQUE constraint failed: person.name. Query: "INSERT INTO person (name, age) VALUES (?1, ?2)".
+  Fatal error: exception Response from <sqlite3:///test.db> failed: UNIQUE constraint failed: person.name. Query: "INSERT INTO person (name, age) VALUES (?1, ?2)\nRETURNING person.id".
   [2]

--- a/test/static/test-insert-multiple.t
+++ b/test/static/test-insert-multiple.t
@@ -1,9 +1,14 @@
   $ ../test_static_person.exe init test.db
   $ ../test_static_person.exe add test.db john 30
+  - id: 1
   $ ../test_static_person.exe add test.db sally 15
+  - id: 2
   $ ../test_static_person.exe add test.db barry 14
+  - id: 3
   $ ../test_static_person.exe add test.db bob 20
+  - id: 4
   $ ../test_static_person.exe add test.db harry 10
+  - id: 5
   $ ../test_static_person.exe list test.db
   [0] - name: john; age: 30
   [1] - name: sally; age: 15

--- a/test/static/test-insert.t
+++ b/test/static/test-insert.t
@@ -1,4 +1,5 @@
   $ ../test_static_person.exe init test.db
   $ ../test_static_person.exe add test.db john 30
+  - id: 1
   $ ../test_static_person.exe list test.db
   [0] - name: john; age: 30

--- a/test/static/test-update.t
+++ b/test/static/test-update.t
@@ -1,9 +1,14 @@
   $ ../test_static_person.exe init test.db
   $ ../test_static_person.exe add test.db john 30
+  - id: 1
   $ ../test_static_person.exe add test.db sally 15
+  - id: 2
   $ ../test_static_person.exe add test.db barry 14
+  - id: 3
   $ ../test_static_person.exe add test.db bob 20
+  - id: 4
   $ ../test_static_person.exe add test.db harry 10
+  - id: 5
   $ ../test_static_person.exe update test.db harry 15
   $ ../test_static_person.exe list test.db
   [0] - name: john; age: 30


### PR DESCRIPTION
This patch adds support for the RETURNING clause on INSERT, DELETE, and UPDATE statements. The RETURNING clause is non-standard, but has been supported by PostgreSQL since basically forever (version 8.2, released 2006-12-05) and by SQLite since version 3.35.0 (released 2021-03-12).

See also https://www.sqlite.org/lang_returning.html and https://www.postgresql.org/docs/current/dml-returning.html