### PR TITLE
feat: add Query.table for joins directly on a table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build/
+_opam/

--- a/lib/petrol.mli
+++ b/lib/petrol.mli
@@ -941,7 +941,7 @@ module Query : sig
   type ('a, 'b, 'd, 'c) join_fun =
     ?op:join_op ->
     on:bool Expr.t -> ('b, 'd) t -> ('c, 'a) t -> ('c, 'a) t
-    constraint 'a = [< `SELECT_CORE ] constraint 'd = [< `SELECT_CORE | `SELECT ]
+    constraint 'a = [< `SELECT_CORE ] constraint 'd = [< `SELECT_CORE | `SELECT | `TABLE]
   (** [('a,'b,'c,'d) join_fun] defines the type of an SQL function
       that corresponds to SQL's JOIN clause.  *)
 
@@ -985,7 +985,7 @@ module Query : sig
   val having : ([< `SELECT | `SELECT_CORE ], 'c) having_fun
   (** [having fields expr] corresponds to the SQL [{expr} HAVING {fields}].  *)
 
-  val join : ([ `SELECT_CORE ], 'b, [< `SELECT_CORE | `SELECT ], 'c) join_fun
+  val join : ([ `SELECT_CORE ], 'b, [< `SELECT_CORE | `SELECT | `TABLE], 'c) join_fun
   (** [join ?op ~on oexpr expr] corresponds to the SQL [{expr} {op} JOIN {oexpr} ON {expr}].
 
       The ordering of the last two arguments has been chosen to allow
@@ -1001,6 +1001,9 @@ module Query : sig
   val limit :
     int Expr.t -> ('a, [< `SELECT | `SELECT_CORE ]) t -> ('a, [> `SELECT ]) t
   (** [limit count expr] corresponds to the SQL [{expr} LIMIT {count}].  *)
+
+  val table : table_name -> (_, [> `TABLE]) t
+  (** Make a table for a join  *)
 
   val offset
     : int Expr.t -> ('a, [< `SELECT | `SELECT_CORE ]) t -> ('a, [> `SELECT ]) t


### PR DESCRIPTION
Hi!

First off, really enjoying petrol. Thanks for the library.

I was wondering if this would be a welcome addition to the library. I'm not necessarily 100% sold on using `TABLE` as a new variant, but I wasn't sure how else to handle this easily (and also allows inserting tables into other locations in queries later, if needed).

Usage looks now like this:

```ocaml
    Query.select ~from:table Expr.(User.f_twitch_display_name :: fields)
    |> Query.join
         ~op:Query.INNER
         ~on:Expr.(User.f_twitch_user_id = f_user_id)
         (Query.table User.table)
```
Printed:

```sql
SELECT users.twitch_display_name, suggestions.id, ...
FROM suggestions
   INNER JOIN users ON users.twitch_user_id = suggestions.user_id
```
Thanks