### PR TITLE
feat: add nullable fields and handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build/
+_opam/

--- a/lib/expr.ml
+++ b/lib/expr.ml
@@ -29,6 +29,12 @@ module Common = struct
   let bl i = Types.CONST (i,Type.bool)
   let vl ~ty i = Types.CONST (i,ty)
 
+  let vl_opt ~ty i = Types.CONST (i, NULLABLE ty)
+  let i_opt i = Types.CONST (i, NULLABLE INTEGER)
+  let f_opt i = Types.CONST (i, NULLABLE REAL)
+  let s_opt i = Types.CONST (i, NULLABLE TEXT)
+  let bl_opt i = Types.CONST (i, NULLABLE Type.bool)
+
   let i_stat i = Types.CONST_STATIC (i,INTEGER)
   let f_stat i = Types.CONST_STATIC (i,REAL)
   let s_stat i = Types.CONST_STATIC (i,TEXT)

--- a/lib/petrol.ml
+++ b/lib/petrol.ml
@@ -43,6 +43,7 @@ module Sqlite3 = struct
     let real = Type.real
     let text = Type.text
     let bool = Type.bool
+    let null_ty = Type.null_ty
 
     include Type.Sqlite3
 

--- a/lib/petrol.mli
+++ b/lib/petrol.mli
@@ -164,6 +164,8 @@ module Sqlite3 : sig
     val blob : string t
     (** [blob] represents the SQL BLOB type.  *)
 
+    val null_ty : 'a t -> 'a option t
+
     module Numeric = Type.Numeric
 
   end 
@@ -227,6 +229,11 @@ module Sqlite3 : sig
     val s : string -> string t
     (** [s v] returns an expression that evaluates to the string value
         [v].  *)
+
+    val i_opt : int option -> int option t
+    val f_opt : float option -> float option t
+    val s_opt : string option -> string option t
+    val bl_opt : bool option -> bool option t
 
     val b : string -> string t
     (** [b v] returns an expression that evaluates to the bytes value

--- a/lib/petrol.mli
+++ b/lib/petrol.mli
@@ -527,6 +527,11 @@ module Postgres : sig
     (** [s v] returns an expression that evaluates to the string value
         [v].  *)
 
+    val i_opt : int option -> int option t
+    val f_opt : float option -> float option t
+    val s_opt : string option -> string option t
+    val bl_opt : bool option -> bool option t
+
     val bl : bool -> bool t
     (** [bl v] returns an expression that evaluates to the bool value
         [v].  *)

--- a/lib/petrol.mli
+++ b/lib/petrol.mli
@@ -941,7 +941,7 @@ module Query : sig
   type ('a, 'b, 'd, 'c) join_fun =
     ?op:join_op ->
     on:bool Expr.t -> ('b, 'd) t -> ('c, 'a) t -> ('c, 'a) t
-    constraint 'a = [< `SELECT_CORE ] constraint 'd = [< `SELECT_CORE | `SELECT ]
+    constraint 'a = [< `SELECT_CORE ] constraint 'd = [< `SELECT_CORE | `SELECT | `TABLE]
   (** [('a,'b,'c,'d) join_fun] defines the type of an SQL function
       that corresponds to SQL's JOIN clause.  *)
 
@@ -985,7 +985,7 @@ module Query : sig
   val having : ([< `SELECT | `SELECT_CORE ], 'c) having_fun
   (** [having fields expr] corresponds to the SQL [{expr} HAVING {fields}].  *)
 
-  val join : ([ `SELECT_CORE ], 'b, [< `SELECT_CORE | `SELECT ], 'c) join_fun
+  val join : ([ `SELECT_CORE ], 'b, [< `SELECT_CORE | `SELECT | `TABLE], 'c) join_fun
   (** [join ?op ~on oexpr expr] corresponds to the SQL [{expr} {op} JOIN {oexpr} ON {expr}].
 
       The ordering of the last two arguments has been chosen to allow
@@ -1001,6 +1001,9 @@ module Query : sig
   val limit :
     int Expr.t -> ('a, [< `SELECT | `SELECT_CORE ]) t -> ('a, [> `SELECT ]) t
   (** [limit count expr] corresponds to the SQL [{expr} LIMIT {count}].  *)
+
+  val table : table_name -> (_, [> `TABLE]) t
+  (** Make a table for a join  *)
 
   val offset
     : int Expr.t -> ('a, [< `SELECT | `SELECT_CORE ]) t -> ('a, [> `SELECT ]) t


### PR DESCRIPTION
Wondering if you are thinking there are any better options than this kind of idea?

This let's users do:

```ocaml
    let table, fields =
      StaticSchema.declare_table
        schema
        ~name:"optional"
        ~constraints:[]
        (let open Schema in
         [ field "id" ~ty:Type.int ~constraints:[ primary_key (); not_null () ]
         ; field "username" ~ty:(Type.null_ty Type.text)
         ])
```

and encode the possibility of null in the field type.