### PR TITLE
fix tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,11 +1,9 @@
 (executables (names test_static_person test_versioned_bookmark test_postgres_static test_postgres_versioned)
   (modules (:standard \ "test_utils"))
- (enabled_if (= %{profile} test))
- (libraries test_utils petrol caqti caqti-lwt caqti-driver-sqlite3 caqti-driver-postgresql))
+ (libraries test_utils petrol caqti caqti-lwt.unix caqti-driver-sqlite3 caqti-driver-postgresql))
 
 (library (name test_utils)
  (modules "test_utils")
- (enabled_if (= %{profile} test))
- (libraries petrol caqti caqti-lwt caqti-driver-sqlite3 caqti-driver-postgresql))
+ (libraries petrol caqti caqti-lwt.unix caqti-driver-sqlite3 caqti-driver-postgresql))
 
 

--- a/test/postgres_static/dune
+++ b/test/postgres_static/dune
@@ -1,2 +1,1 @@
-(cram (deps ../test_postgres_static.exe)
- (enabled_if (= %{profile} test)))
+(cram (deps ../test_postgres_static.exe))

--- a/test/postgres_static/test-insert-duplicate.t
+++ b/test/postgres_static/test-insert-duplicate.t
@@ -6,7 +6,7 @@
   $ ../test_postgres_static.exe testing_insert_duplicate add bob 20
   $ ../test_postgres_static.exe testing_insert_duplicate add harry 10
   $ ../test_postgres_static.exe testing_insert_duplicate add harry 10
-  Fatal error: exception Request to <postgresql://localhost:5432/testing_insert_duplicate> failed: ERROR:  duplicate key value violates unique constraint "unique_names"
+  Fatal error: exception Request to <postgresql:///testing_insert_duplicate> failed: ERROR:  duplicate key value violates unique constraint "unique_names"
   DETAIL:  Key (name)=(harry) already exists.
    Query: "INSERT INTO person (name, age) VALUES ($1, $2)".
   [2]

--- a/test/postgres_versioned/dune
+++ b/test/postgres_versioned/dune
@@ -1,3 +1,1 @@
-(cram
- (deps ../test_postgres_versioned.exe)
- (enabled_if (= %{profile} test)))
+(cram (deps ../test_postgres_versioned.exe))

--- a/test/static/dune
+++ b/test/static/dune
@@ -1,2 +1,1 @@
-(cram (deps ../test_static_person.exe)
- (enabled_if (= %{profile} test)))
+(cram (deps ../test_static_person.exe))

--- a/test/static/test-insert-duplicate.t
+++ b/test/static/test-insert-duplicate.t
@@ -10,5 +10,5 @@
   $ ../test_static_person.exe add test.db harry 10
   - id: 5
   $ ../test_static_person.exe add test.db harry 10
-  Fatal error: exception Response from <sqlite3:///test.db> failed: UNIQUE constraint failed: person.name. Query: "INSERT INTO person (name, age) VALUES (?1, ?2)\nRETURNING person.id".
+  Fatal error: exception Request to <sqlite3:///test.db> failed: UNIQUE constraint failed: person.name (ERC#2067). Query: "INSERT INTO person (name, age) VALUES (?1, ?2)\nRETURNING person.id".
   [2]

--- a/test/test_postgres_static.ml
+++ b/test/test_postgres_static.ml
@@ -117,7 +117,7 @@ let () =
     Lwt.return_ok ()
   |  "insert-random" :: _ ->
     let fname = Sys.argv.(2) in
-    let* conn = Caqti_lwt.connect (Uri.of_string ("sqlite3://:" ^ fname)) in
+    let* conn = Caqti_lwt_unix.connect (Uri.of_string ("sqlite3://:" ^ fname)) in
     let* _ = Petrol.StaticSchema.initialise db conn in
     let person = Person.random () in
     let* _ = Person.Sql.insert person conn in

--- a/test/test_static_person.ml
+++ b/test/test_static_person.ml
@@ -116,7 +116,7 @@ let () =
       Lwt.return_ok ()
     |  "insert-random", _ ->
       let fname = Sys.argv.(2) in
-      let* conn = Caqti_lwt.connect (Uri.of_string ("sqlite3://:" ^ fname)) in
+      let* conn = Caqti_lwt_unix.connect (Uri.of_string ("sqlite3://:" ^ fname)) in
       let* _ = Petrol.StaticSchema.initialise db conn in
       let person = Person.random () in
       let* (pid, ()) = Person.Sql.insert person conn in

--- a/test/test_utils.ml
+++ b/test/test_utils.ml
@@ -16,7 +16,7 @@ let main f =
   let open Lwt_result.Syntax in
   let fname = Sys.argv.(2) in
   run begin
-    let* conn = Caqti_lwt.connect (Uri.of_string ("sqlite3://:" ^ fname)) in
+    let* conn = Caqti_lwt_unix.connect (Uri.of_string ("sqlite3://:" ^ fname)) in
     let args = List.init (Array.length Sys.argv - 3) (fun ind -> Sys.argv.(3 + ind)) in
     match f conn (Sys.argv.(1), args) with
     | computation ->
@@ -30,17 +30,17 @@ let main_postgres f =
     let args = List.init (Array.length Sys.argv - 1) (fun ind -> Sys.argv.(1 + ind)) in
     match[@warning "-8"] args with
     | ["createdb"; name] ->
-      let* (module DB) = Caqti_lwt.connect (Uri.of_string "postgresql://localhost:5432") in
+      let* (module DB) = Caqti_lwt_unix.connect (Uri.of_string "postgresql://") in
       Lwt.bind (DB.exec (Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit)
                            (Format.sprintf {sql| CREATE DATABASE %s |sql} name)) ()) @@ 
       fun err -> Lwt.bind (DB.disconnect ()) @@ fun () -> Lwt.return err
     | ["dropdb"; name] ->
-      let* (module DB) = Caqti_lwt.connect (Uri.of_string "postgresql://localhost:5432") in
+      let* (module DB) = Caqti_lwt_unix.connect (Uri.of_string "postgresql://") in
       Lwt.bind (DB.exec (Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit)
                            (Format.sprintf {sql| DROP DATABASE IF EXISTS %s WITH (FORCE) |sql} name)) ()) @@
       fun err -> Lwt.bind (DB.disconnect ()) @@ fun () -> Lwt.return err
     | name :: args ->
-      let* ((module DB) as conn) = Caqti_lwt.connect (Uri.of_string (Format.sprintf "postgresql://localhost:5432/%s" name)) in
+      let* ((module DB) as conn) = Caqti_lwt_unix.connect (Uri.of_string (Format.sprintf "postgresql:///%s" name)) in
       try
         Lwt.bind begin match f conn args with
           | computation -> computation

--- a/test/versioned/dune
+++ b/test/versioned/dune
@@ -1,3 +1,2 @@
 (cram
- (deps ../test_versioned_bookmark.exe)
- (enabled_if (= %{profile} test)))
+ (deps ../test_versioned_bookmark.exe))


### PR DESCRIPTION
1. Make tests compile with caqti >= 2.0.0
2. Fix an sqlite error message (I'm using sqlite 3.50.4)
3. Use postgresql's peer authentication method. I couldn't figure out how to specify a postgres password, so I removed ``localhost:5432`` from the postgresql URIs. Now, if a postgres user and database with the same name as my unix user exists, authentication works without password. I create the postgres user like this:
    ```
    CREATE USER christian CREATEDB;
    CREATE DATABASE christian OWNER christian;
    ```
5. Allow running ``dune test`` without the ``--profile=test`` flag by removing all the ``(enabled_if (= %{profile} test))`` conditions. Please let me know if these conditions are still important.